### PR TITLE
added test on a deletion of a newly created project

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,7 @@ dependencies {
             "io.rest-assured:rest-assured:4.3.1",
             "io.qameta.allure:allure-rest-assured:$allureVersion",
             "org.aeonbits.owner:owner:1.0.12",
+            "com.github.javafaker:javafaker:1.0.2",
             "org.assertj:assertj-core:3.19.0",
             "org.junit.jupiter:junit-jupiter-api:$junitVersion")
     testRuntimeOnly(

--- a/src/test/java/cloud/autotests/data/MenuItem.java
+++ b/src/test/java/cloud/autotests/data/MenuItem.java
@@ -7,7 +7,8 @@ public enum MenuItem {
     LAUNCHES("Launches"),
     ANALYTICS("Analytics"),
     DEFECTS("Defects"),
-    JOBS("Jobs");
+    JOBS("Jobs"),
+    SETTINGS("Settings");
 
     private final String displayedName;
 

--- a/src/test/java/cloud/autotests/pages/MainPage.java
+++ b/src/test/java/cloud/autotests/pages/MainPage.java
@@ -1,0 +1,41 @@
+package cloud.autotests.pages;
+
+import io.qameta.allure.Step;
+
+import static com.codeborne.selenide.Selenide.*;
+import static io.qameta.allure.Allure.step;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class MainPage {
+
+    @Step("Open main page")
+    public void openPage() {
+                open("");
+    }
+
+    public ProjectsTable getProjectsTable() {
+        return new ProjectsTable();
+    }
+
+    @Step("Creating a new project from a main page")
+    public ProjectPage createNewProject(String projectName) {
+        step("Click on a button 'New project'", () ->
+            $("button.Button_style_success").click()
+        );
+        step("Fill obligatory fields name with {projectName} and abbreviation with {projectAbbr}", () -> {
+            $("input[name=name]").setValue(projectName);
+        });
+        step("Click submit, creating {projectName} project", () ->
+            $("button.Button_style_success[type=submit]").click()
+        );
+        return new ProjectPage();
+    }
+
+    public void filterProject(String projectName) {
+
+        step("confirm the project {projectName} deletion", () -> {
+            $("input.HomeLayout__search").setValue(projectName);
+            sleep(500); // иначе через раз падает
+        });
+    }
+}

--- a/src/test/java/cloud/autotests/pages/ProjectPage.java
+++ b/src/test/java/cloud/autotests/pages/ProjectPage.java
@@ -2,6 +2,7 @@ package cloud.autotests.pages;
 
 import cloud.autotests.data.MenuItem;
 import cloud.autotests.pages.components.Sidebar;
+import com.codeborne.selenide.Condition;
 import com.codeborne.selenide.ElementsCollection;
 import com.codeborne.selenide.SelenideElement;
 import io.qameta.allure.Step;
@@ -10,6 +11,7 @@ import static com.codeborne.selenide.Condition.text;
 import static com.codeborne.selenide.Condition.visible;
 import static com.codeborne.selenide.Selenide.$;
 import static com.codeborne.selenide.Selenide.$$;
+import static io.qameta.allure.Allure.step;
 
 public class ProjectPage {
 
@@ -35,5 +37,11 @@ public class ProjectPage {
         launchesWidget.should(visible);
         automationTrendWidget.should(visible);
         muteTrendWidget.should(visible);
+    }
+
+    @Step("Delete project: Push 'delete' button and confirm a deletion")
+    public void deleteProject() {
+        $$("button.Button_style_danger").find(Condition.text("Delete project")).click();
+        $$("button.Button_style_danger").find(Condition.exactText("Delete")).click();
     }
 }

--- a/src/test/java/cloud/autotests/pages/ProjectsTable.java
+++ b/src/test/java/cloud/autotests/pages/ProjectsTable.java
@@ -12,10 +12,12 @@ import static com.codeborne.selenide.Selenide.$$;
 public class ProjectsTable {
 
     private ElementsCollection tableRows = $$("li.list-row");
+    public int size;
 
     @Step("Navigate to project `{projectName}`")
     public ProjectPage navigateTo(String projectName) {
         tableRows.find(text(projectName)).$(".ProjectCard__name > a").click();
+        size = tableRows.size();
         return new ProjectPage();
     }
 }

--- a/src/test/java/cloud/autotests/pages/ProjectsTable.java
+++ b/src/test/java/cloud/autotests/pages/ProjectsTable.java
@@ -12,12 +12,14 @@ import static com.codeborne.selenide.Selenide.$$;
 public class ProjectsTable {
 
     private ElementsCollection tableRows = $$("li.list-row");
-    public int size;
 
     @Step("Navigate to project `{projectName}`")
     public ProjectPage navigateTo(String projectName) {
         tableRows.find(text(projectName)).$(".ProjectCard__name > a").click();
-        size = tableRows.size();
         return new ProjectPage();
+    }
+
+    public int getProjectTableSize() {
+        return tableRows.size();
     }
 }

--- a/src/test/java/cloud/autotests/tests/ProjectTestsDynamic.java
+++ b/src/test/java/cloud/autotests/tests/ProjectTestsDynamic.java
@@ -1,0 +1,52 @@
+package cloud.autotests.tests;
+
+import cloud.autotests.data.MenuItem;
+import cloud.autotests.helpers.WithLogin;
+import cloud.autotests.pages.ProjectsTable;
+import cloud.autotests.pages.components.Sidebar;
+import com.codeborne.selenide.Condition;
+import io.qameta.allure.Story;
+import org.junit.jupiter.api.Test;
+
+import static com.codeborne.selenide.Selenide.*;
+import static io.qameta.allure.Allure.step;
+import static org.assertj.core.api.Assertions.*;
+
+@Story("Projects tests dynamic interactions")
+public class ProjectTestsDynamic extends TestBase{
+
+    @WithLogin
+    @Test
+    void deleteProjectCreatedInThisTest(){
+        //precondition
+        String projectName = "testuser-testproject-toBeDeleted";
+        String projectAbbr = "TD";
+
+        step("Open main page", () ->
+             open(""));
+        step("click on a button 'New project'", () ->
+             $$("button.Button_style_success").find(Condition.text("New project")).click());
+        step("fill obligatory fields name with {projectName} and abbreviation with {projectAbbr}", () -> {
+             $("input[name=name]").setValue(projectName);
+             $("input[name=abbr]").setValue(projectAbbr);
+        });
+        step("click submit, creating {projectName} project", () ->
+            $("button.Button_style_success[type=submit]").click()
+        );
+        //test
+        step("navigate to 'settings' in sidebar and click", () -> {
+            Sidebar sidebar = new Sidebar();
+            sidebar.navigateTo(MenuItem.SETTINGS);
+        });
+        step("push 'delete' button and confirm a deletion'", () -> {
+            $$("button.Button_style_danger").find(Condition.text("Delete project")).click();
+            $$("button.Button_style_danger").find(Condition.exactText("Delete")).click();
+        });
+        //check if all have gone as it was planned
+        step("confirm the project {projectName} deletion", () -> {
+            $("input.HomeLayout__search").setValue("testuser-testproject-toBeDeleted");
+            ProjectsTable projectsTable = new ProjectsTable();
+            assertThat(projectsTable.size).isEqualTo(0);
+        });
+    }
+}

--- a/src/test/java/cloud/autotests/tests/ProjectTestsDynamic.java
+++ b/src/test/java/cloud/autotests/tests/ProjectTestsDynamic.java
@@ -2,51 +2,36 @@ package cloud.autotests.tests;
 
 import cloud.autotests.data.MenuItem;
 import cloud.autotests.helpers.WithLogin;
+import cloud.autotests.pages.MainPage;
+import cloud.autotests.pages.ProjectPage;
 import cloud.autotests.pages.ProjectsTable;
-import cloud.autotests.pages.components.Sidebar;
-import com.codeborne.selenide.Condition;
+import com.github.javafaker.Faker;
 import io.qameta.allure.Story;
+import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.Test;
 
-import static com.codeborne.selenide.Selenide.*;
-import static io.qameta.allure.Allure.step;
-import static org.assertj.core.api.Assertions.*;
-
 @Story("Projects tests dynamic interactions")
-public class ProjectTestsDynamic extends TestBase{
+public class ProjectTestsDynamic extends TestBase {
 
     @WithLogin
     @Test
-    void deleteProjectCreatedInThisTest(){
-        //precondition
-        String projectName = "testuser-testproject-toBeDeleted";
-        String projectAbbr = "TD";
+    void deleteProjectCreatedInThisTest() {
+        //предусловия
+        String projectName = "testuser-testproject-toBeDeleted" + (new Faker()).random().hex(6);
+        MainPage mainPage = new MainPage();
+        mainPage.openPage();
+        ProjectPage projectPage = mainPage.createNewProject(projectName);
 
-        step("Open main page", () ->
-             open(""));
-        step("click on a button 'New project'", () ->
-             $$("button.Button_style_success").find(Condition.text("New project")).click());
-        step("fill obligatory fields name with {projectName} and abbreviation with {projectAbbr}", () -> {
-             $("input[name=name]").setValue(projectName);
-             $("input[name=abbr]").setValue(projectAbbr);
-        });
-        step("click submit, creating {projectName} project", () ->
-            $("button.Button_style_success[type=submit]").click()
-        );
-        //test
-        step("navigate to 'settings' in sidebar and click", () -> {
-            Sidebar sidebar = new Sidebar();
-            sidebar.navigateTo(MenuItem.SETTINGS);
-        });
-        step("push 'delete' button and confirm a deletion'", () -> {
-            $$("button.Button_style_danger").find(Condition.text("Delete project")).click();
-            $$("button.Button_style_danger").find(Condition.exactText("Delete")).click();
-        });
-        //check if all have gone as it was planned
-        step("confirm the project {projectName} deletion", () -> {
-            $("input.HomeLayout__search").setValue("testuser-testproject-toBeDeleted");
-            ProjectsTable projectsTable = new ProjectsTable();
-            assertThat(projectsTable.size).isEqualTo(0);
-        });
+        //тест
+        projectPage.getSidebar().navigateTo(MenuItem.SETTINGS);
+        projectPage.deleteProject();
+        mainPage.filterProject(projectName);
+
+        //проверка
+        ProjectsTable projectsTable = mainPage.getProjectsTable();
+        SoftAssertions softly = new SoftAssertions(); //чтобы выставить тайминг в проверке остановился на 500 мс иначе тест периодически падает
+        softly.assertThat(projectsTable.getProjectTableSize()).isEqualTo(0);
+        softly.assertAll();
+
     }
 }


### PR DESCRIPTION
added the test: "checking project deletion process", 
menu items enum extended with item "SETTINGS", 
ProjectTable added a public variable with list size.

Test-case description:

> **Preconditions**

- user logged in to the allure.testOps
- new project with **known** name is created

> **Actions**

- From the project page navigates in Sidebar to Settings
- Push delete button and confirm a deletion

> **Assert**

- Search for the project by **known** name
- Ascertain that the project list after this search is empty 