### PR TITLE
Export test case to CSV tests

### DIFF
--- a/src/test/java/cloud/autotests/pages/TestCasesTable.java
+++ b/src/test/java/cloud/autotests/pages/TestCasesTable.java
@@ -1,10 +1,15 @@
 package cloud.autotests.pages;
 
+import com.codeborne.selenide.Condition;
 import com.codeborne.selenide.ElementsCollection;
 import io.qameta.allure.Step;
+import org.openqa.selenium.By;
 
 import static com.codeborne.selenide.CollectionCondition.size;
+import static com.codeborne.selenide.Condition.enabled;
 import static com.codeborne.selenide.Condition.text;
+import static com.codeborne.selenide.Selectors.byText;
+import static com.codeborne.selenide.Selenide.$;
 import static com.codeborne.selenide.Selenide.$$;
 
 public class TestCasesTable {
@@ -14,6 +19,28 @@ public class TestCasesTable {
     @Step("Check test cases table size")
     public void shouldHaveSize(int expectedSize) {
         rows.shouldHave(size(expectedSize));
+    }
+
+    @Step("Choose test case by name: [{nameTestCase}]")
+    public void chooseTestCase(String nameTestCase) {
+        rows.find(text(nameTestCase)).find(".LoadableTreeNodeCheckbox").click();
+    }
+
+    @Step("Click bulk actions button")
+    public void clickBulkActionsButton() {
+        $(".LoadableTreeControlPanel").$(By.tagName("button")).click();
+    }
+
+    @Step("Export test case to CSV")
+    public void exportTestCaseToCSV() {
+        $(".tippy-content").$(byText("Export to CSV")).click();
+        $(".Form__controls").$(byText("Submit")).click();
+    }
+
+    @Step("Check export to CSV finished")
+    public void checkExportToCSVFinished() {
+        $(".Label_status_passed").shouldHave(text("ready"));
+        $(".ExportRequest__link").$("a").shouldBe(Condition.enabled);
     }
 
     public void navigateToTestByStatus(String statusName) {

--- a/src/test/java/cloud/autotests/tests/TestCaseExportToCSVTests.java
+++ b/src/test/java/cloud/autotests/tests/TestCaseExportToCSVTests.java
@@ -1,0 +1,32 @@
+package cloud.autotests.tests;
+
+import cloud.autotests.config.App;
+import cloud.autotests.data.MenuItem;
+import cloud.autotests.helpers.WithLogin;
+import cloud.autotests.pages.ProjectPage;
+import cloud.autotests.pages.ProjectsTable;
+import cloud.autotests.pages.TestCasesTable;
+import io.qameta.allure.Story;
+import org.junit.jupiter.api.Test;
+
+import static com.codeborne.selenide.Selenide.open;
+
+@Story("Export test case to CSV tests")
+public class TestCaseExportToCSVTests extends TestBase {
+    private static final String PROJECT_NAME = "teacher qa_guru_diplom_project";
+    private String testCaseName = "2) Проверка работы слайдера на главной странице";
+
+    @Test
+    @WithLogin
+    void exportToCSV() {
+        ProjectsTable projectsTable = open(App.config.webUrl(), ProjectsTable.class);
+        ProjectPage projectPage = projectsTable.navigateTo(PROJECT_NAME);
+        projectPage.getSidebar().navigateTo(MenuItem.TEST_CASES);
+
+        TestCasesTable testCasesTable = new TestCasesTable();
+        testCasesTable.chooseTestCase(testCaseName);
+        testCasesTable.clickBulkActionsButton();
+        testCasesTable.exportTestCaseToCSV();
+        testCasesTable.checkExportToCSVFinished();
+    }
+}


### PR DESCRIPTION
### Тест экспорта тест кейса в файл в формате CSV

**_Предусловие:_**

-  Пользователь выполнил вход в Allure testOps
-  В Allure testOps существует проект, содержащий тест кейсы

**_Действия:_**

-  Открыть Allure testOps
-   В списке проектов найти проект с указанным наименованием и перейти к нему
-   Из боковой панели перейти к странице тест кейсов
-   Активировать чек-бокс с известным наименованием тест кейса
-   В меню групповых операций выбрать пункт 'Export to CSV'
-   В модальном окне 'Export to CSV' подтвердить выполнение групповой операции, нажав кнопку 'Submit'
  
_**Проверка:**_
 
- Убедиться, что экспорт завершен (отображается статус 'ready') и сформирована ссылка для скачивания файла