### PR TITLE
updated: Export test case to CSV with check downloaded file test

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,7 @@ dependencies {
             "com.github.javafaker:javafaker:1.0.2",
             "org.assertj:assertj-core:3.19.0",
             "org.junit.jupiter:junit-jupiter:$junitVersion")
+
     testRuntimeOnly(
             "org.slf4j:slf4j-simple:1.7.29",
             "org.junit.jupiter:junit-jupiter-engine:$junitVersion")

--- a/src/test/java/cloud/autotests/api/Authorization.java
+++ b/src/test/java/cloud/autotests/api/Authorization.java
@@ -22,6 +22,21 @@ public class Authorization {
     }
 
     public String getAccessToken() {
-      return getAuthorizationResponse().path("access_token");
+        return getAuthorizationResponse().path("access_token");
+    }
+
+    public Response authorizationViaApi() {
+        String xsrfToken = getAuthorizationResponse().getBody().jsonPath().get("jti");
+        return given()
+                .filter(AllureRestAssuredFilter.withCustomTemplates())
+                .header("X-XSRF-TOKEN", xsrfToken)
+                .header("Cookie", "XSRF-TOKEN=" + xsrfToken)
+                .formParam("username", App.config.userLogin())
+                .formParam("password", App.config.userPassword())
+                .when()
+                .post("/api/login/system")
+                .then()
+                .statusCode(200)
+                .extract().response();
     }
 }

--- a/src/test/java/cloud/autotests/helpers/LoginExtension.java
+++ b/src/test/java/cloud/autotests/helpers/LoginExtension.java
@@ -3,17 +3,20 @@ package cloud.autotests.helpers;
 import cloud.autotests.api.Authorization;
 import org.junit.jupiter.api.extension.BeforeEachCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
+import org.openqa.selenium.Cookie;
 
-import static com.codeborne.selenide.Selenide.localStorage;
 import static com.codeborne.selenide.Selenide.open;
+import static com.codeborne.selenide.WebDriverRunner.getWebDriver;
 
 public class LoginExtension implements BeforeEachCallback {
     @Override
     public void beforeEach(ExtensionContext context) {
+        String ALLURE_COOKIE_NAME = "ALLURE_TESTOPS_SESSION";
+
         String authorizationResponse =
-                new Authorization().getAuthorizationResponse().asString();
+                new Authorization().authorizationViaApi().getCookie(ALLURE_COOKIE_NAME);
 
         open("/favicon.ico");
-        localStorage().setItem("AS_AUTH_2", authorizationResponse);
+        getWebDriver().manage().addCookie(new Cookie(ALLURE_COOKIE_NAME, authorizationResponse));
     }
 }

--- a/src/test/java/cloud/autotests/pages/ProjectsListPage.java
+++ b/src/test/java/cloud/autotests/pages/ProjectsListPage.java
@@ -36,8 +36,8 @@ public class ProjectsListPage {
 
     public void filterProject(String projectName) {
         step("confirm the project {projectName} deletion", () -> {
-            $("input.HomeLayout__search").setValue(projectName);
-            sleep(500); // иначе через раз падает
+            $("input.ProjectsListControlsBar__search").setValue(projectName);
+           // sleep(500); // иначе через раз падает
         });
     }
 }

--- a/src/test/java/cloud/autotests/pages/ProjectsTable.java
+++ b/src/test/java/cloud/autotests/pages/ProjectsTable.java
@@ -15,7 +15,7 @@ public class ProjectsTable {
 
     @Step("Navigate to project `{projectName}`")
     public ProjectPage navigateTo(String projectName) {
-        tableRows.find(text(projectName)).$(".ProjectCard__name > a").click();
+        tableRows.find(text(projectName)).$(".ProjectRow__name > a").click();
         return new ProjectPage();
     }
 

--- a/src/test/java/cloud/autotests/pages/TestCasesTable.java
+++ b/src/test/java/cloud/autotests/pages/TestCasesTable.java
@@ -1,10 +1,15 @@
 package cloud.autotests.pages;
 
+import com.codeborne.selenide.Condition;
 import com.codeborne.selenide.ElementsCollection;
 import io.qameta.allure.Step;
+import org.openqa.selenium.By;
 
 import static com.codeborne.selenide.CollectionCondition.size;
+import static com.codeborne.selenide.Condition.enabled;
 import static com.codeborne.selenide.Condition.text;
+import static com.codeborne.selenide.Selectors.byText;
+import static com.codeborne.selenide.Selenide.$;
 import static com.codeborne.selenide.Selenide.$$;
 
 public class TestCasesTable {
@@ -14,6 +19,28 @@ public class TestCasesTable {
     @Step("Check test cases table size")
     public void shouldHaveSize(int expectedSize) {
         rows.shouldHave(size(expectedSize));
+    }
+
+    @Step("Choose test case by name: [{nameTestCase}]")
+    public void chooseTestCase(String nameTestCase) {
+        rows.find(text(nameTestCase)).find(".LoadableTreeNodeCheckbox").click();
+    }
+
+    @Step("Click bulk actions button")
+    public void clickBulkActionsButton() {
+        $(".LoadableTreeControlPanel").$(By.tagName("button")).click();
+    }
+
+    @Step("Export test case to CSV")
+    public void exportTestCaseToCSV() {
+        $(".tippy-content").$(byText("Export to CSV")).click();
+        $(".Form__controls").$(byText("Submit")).click();
+    }
+
+    @Step("Check export to CSV finished")
+    public void checkExportToCSVFinished() {
+        $(".Label_status_passed").shouldHave(text("ready"));
+        $(".ExportRequest__link").$("a").shouldBe(Condition.enabled);
     }
 
     public void navigateToTestByStatus(String statusName) {

--- a/src/test/java/cloud/autotests/pages/TestCasesTable.java
+++ b/src/test/java/cloud/autotests/pages/TestCasesTable.java
@@ -1,12 +1,12 @@
 package cloud.autotests.pages;
 
+import cloud.autotests.pages.components.ExportTestCaseToCsvDialog;
 import com.codeborne.selenide.Condition;
 import com.codeborne.selenide.ElementsCollection;
 import io.qameta.allure.Step;
 import org.openqa.selenium.By;
 
 import static com.codeborne.selenide.CollectionCondition.size;
-import static com.codeborne.selenide.Condition.enabled;
 import static com.codeborne.selenide.Condition.text;
 import static com.codeborne.selenide.Selectors.byText;
 import static com.codeborne.selenide.Selenide.$;
@@ -27,20 +27,10 @@ public class TestCasesTable {
     }
 
     @Step("Click bulk actions button")
-    public void clickBulkActionsButton() {
+    public ExportTestCaseToCsvDialog openExportTestCaseToCsvDialog() {
         $(".LoadableTreeControlPanel").$(By.tagName("button")).click();
-    }
-
-    @Step("Export test case to CSV")
-    public void exportTestCaseToCSV() {
         $(".tippy-content").$(byText("Export to CSV")).click();
-        $(".Form__controls").$(byText("Submit")).click();
-    }
-
-    @Step("Check export to CSV finished")
-    public void checkExportToCSVFinished() {
-        $(".Label_status_passed").shouldHave(text("ready"));
-        $(".ExportRequest__link").$("a").shouldBe(Condition.enabled);
+        return new ExportTestCaseToCsvDialog();
     }
 
     public void navigateToTestByStatus(String statusName) {

--- a/src/test/java/cloud/autotests/pages/components/ExportTestCaseToCsvDialog.java
+++ b/src/test/java/cloud/autotests/pages/components/ExportTestCaseToCsvDialog.java
@@ -1,0 +1,33 @@
+package cloud.autotests.pages.components;
+
+import com.codeborne.selenide.Condition;
+import com.codeborne.selenide.DownloadOptions;
+import com.codeborne.selenide.FileDownloadMode;
+import io.qameta.allure.Step;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+
+import static com.codeborne.selenide.Condition.text;
+import static com.codeborne.selenide.Selectors.byText;
+import static com.codeborne.selenide.Selenide.$;
+
+public class ExportTestCaseToCsvDialog {
+
+    @Step("Export test case to CSV")
+    public void exportTestCaseToCSV() {
+        $(".Form__controls").$(byText("Submit")).click();
+    }
+
+    @Step("Check export to CSV finished")
+    public void checkExportToCSVFinished() {
+        $(".Label_status_passed").shouldHave(text("ready"));
+        $(".ExportRequest__link").$("a").shouldBe(Condition.enabled);
+    }
+
+    @Step("Download CSV file")
+    public File downloadCsvFile() throws FileNotFoundException {
+       return $(".ExportRequest__link").download(DownloadOptions.using(FileDownloadMode.FOLDER));
+    }
+
+}

--- a/src/test/java/cloud/autotests/pages/components/Sidebar.java
+++ b/src/test/java/cloud/autotests/pages/components/Sidebar.java
@@ -5,7 +5,7 @@ import com.codeborne.selenide.ElementsCollection;
 import com.codeborne.selenide.SelenideElement;
 import io.qameta.allure.Step;
 
-import static com.codeborne.selenide.Condition.text;
+import static com.codeborne.selenide.Condition.attribute;
 import static com.codeborne.selenide.Selenide.$;
 
 public class Sidebar {
@@ -15,7 +15,7 @@ public class Sidebar {
 
     @Step("Navigate to menu item `{menuName}`")
     public void navigateTo(MenuItem menuName) {
-        menuItems.find(text(menuName.getDisplayedName())).click();
+        menuItems.find(attribute("aria-label", menuName.getDisplayedName())).click();
     }
 
 }

--- a/src/test/java/cloud/autotests/tests/TestCaseExportToCSVTests.java
+++ b/src/test/java/cloud/autotests/tests/TestCaseExportToCSVTests.java
@@ -1,0 +1,32 @@
+package cloud.autotests.tests;
+
+import cloud.autotests.config.App;
+import cloud.autotests.data.MenuItem;
+import cloud.autotests.helpers.WithLogin;
+import cloud.autotests.pages.ProjectPage;
+import cloud.autotests.pages.ProjectsTable;
+import cloud.autotests.pages.TestCasesTable;
+import io.qameta.allure.Story;
+import org.junit.jupiter.api.Test;
+
+import static com.codeborne.selenide.Selenide.open;
+
+@Story("Export test case to CSV tests")
+public class TestCaseExportToCSVTests extends TestBase {
+    private static final String PROJECT_NAME = "teacher qa_guru_diplom_project";
+    private String testCaseName = "2) Проверка работы слайдера на главной странице";
+
+    @Test
+    @WithLogin
+    void exportToCSV() {
+        ProjectsTable projectsTable = open(App.config.webUrl(), ProjectsTable.class);
+        ProjectPage projectPage = projectsTable.navigateTo(PROJECT_NAME);
+        projectPage.getSidebar().navigateTo(MenuItem.TEST_CASES);
+
+        TestCasesTable testCasesTable = new TestCasesTable();
+        testCasesTable.chooseTestCase(testCaseName);
+        testCasesTable.clickBulkActionsButton();
+        testCasesTable.exportTestCaseToCSV();
+        testCasesTable.checkExportToCSVFinished();
+    }
+}

--- a/src/test/java/cloud/autotests/tests/TestCaseExportToCSVTests.java
+++ b/src/test/java/cloud/autotests/tests/TestCaseExportToCSVTests.java
@@ -1,32 +1,45 @@
 package cloud.autotests.tests;
 
-import cloud.autotests.config.App;
 import cloud.autotests.data.MenuItem;
 import cloud.autotests.helpers.WithLogin;
 import cloud.autotests.pages.ProjectPage;
+import cloud.autotests.pages.ProjectsListPage;
 import cloud.autotests.pages.ProjectsTable;
 import cloud.autotests.pages.TestCasesTable;
+import cloud.autotests.pages.components.ExportTestCaseToCsvDialog;
 import io.qameta.allure.Story;
 import org.junit.jupiter.api.Test;
 
-import static com.codeborne.selenide.Selenide.open;
+import java.io.File;
+
+import static io.qameta.allure.Allure.step;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
 
 @Story("Export test case to CSV tests")
 public class TestCaseExportToCSVTests extends TestBase {
     private static final String PROJECT_NAME = "teacher qa_guru_diplom_project";
-    private String testCaseName = "2) Проверка работы слайдера на главной странице";
+    public static final String EXPECTED_CSV_PATH = "src/test/resources/export/report.csv";
+    private static final String TEST_CASE_NAME = "2) Проверка работы слайдера на главной странице";
 
     @Test
     @WithLogin
     void exportToCSV() {
-        ProjectsTable projectsTable = open(App.config.webUrl(), ProjectsTable.class);
+        ProjectsListPage projectsListPage = new ProjectsListPage().openPage();
+        projectsListPage.filterProject(PROJECT_NAME);
+        ProjectsTable projectsTable = projectsListPage.getProjectsTable();
         ProjectPage projectPage = projectsTable.navigateTo(PROJECT_NAME);
         projectPage.getSidebar().navigateTo(MenuItem.TEST_CASES);
 
         TestCasesTable testCasesTable = new TestCasesTable();
-        testCasesTable.chooseTestCase(testCaseName);
-        testCasesTable.clickBulkActionsButton();
-        testCasesTable.exportTestCaseToCSV();
-        testCasesTable.checkExportToCSVFinished();
+        testCasesTable.chooseTestCase(TEST_CASE_NAME);
+
+        ExportTestCaseToCsvDialog exportTestCaseToCsvDialog = testCasesTable.openExportTestCaseToCsvDialog();
+        exportTestCaseToCsvDialog.exportTestCaseToCSV();
+        exportTestCaseToCsvDialog.checkExportToCSVFinished();
+
+        step("File content equals to expected one", () ->
+                assertThat(exportTestCaseToCsvDialog.downloadCsvFile())
+                        .hasSameTextualContentAs(new File(EXPECTED_CSV_PATH), UTF_8));
     }
 }

--- a/src/test/resources/export/report.csv
+++ b/src/test/resources/export/report.csv
@@ -1,0 +1,2 @@
+﻿"ID";"NAME";"DESCRIPTION";"PRECONDITION";"EXPECTED_RESULT";"STATUS";"SCENARIO";"TAG";"EPIC";"FEATURE";"STORY";"COMPONENT";"SUITE";"OWNER";"LEAD";"EXAMPLE"
+"1208";"2) Проверка работы слайдера на главной странице";"";"";"";"Active";"";"web";"";"";"";"";"tests.WGTests";"zhuravel";"";""


### PR DESCRIPTION
### Тест экспорта тест кейса в файл в формате CSV с проверкой содержимого файла

**_Предусловие:_**

- Пользователь выполнил вход в Allure TestOps
- В Allure TestOps существует проект, содержащий тест кейсы

**_Действия:_**

- Открыть Allure TestOps
- В списке проектов найти проект с указанным наименованием и перейти к нему
- Из боковой панели перейти к странице тест кейсов
- Активировать чек-бокс с известным наименованием тест кейса
- В меню групповых операций выбрать пункт 'Export to CSV'
- В модальном окне 'Export to CSV' подтвердить выполнение групповой операции, нажав кнопку 'Submit'
- В модальном окне 'Export to CSV' по завершению экспорта отображается статус 'ready' и сформирована ссылка для скачивания файла
- Скачать CSV-файл, кликнув по сформированной ссылке

**_Проверка:_**

- Убедиться, что экспортированный CSV-файл содержит ожидаемые данные.

